### PR TITLE
speed up prove by enable multicore build and translate input only

### DIFF
--- a/src/main/java/com/abstrlabs/priceprover/LibsnarkCallBack.java
+++ b/src/main/java/com/abstrlabs/priceprover/LibsnarkCallBack.java
@@ -18,6 +18,7 @@ public class LibsnarkCallBack implements Callable<Integer> {
     private static final String VERIFICATION_KEY = "verification.key";
     private static final String PROOF = "proof";
     private static final String TRANSLATE = "translate";
+    private static final String TRANSLATE_INPUT = "translate_input";
     private static final String GENERATE = "generate";
     private static final String PROVE = "prove";
     private static final String CONVERT = "convert";
@@ -77,12 +78,12 @@ public class LibsnarkCallBack implements Callable<Integer> {
             }
         } else {
              /* if it's not the first time, necessary steps:
-             *   1. translate input todo : translate input only
+             *   1. translate input
              *   2. generate proof
              *   Assumptions: already have the circuit, prooving.key and verification.key
              */
-            missionName = "translate xjsnark circuit and input to libsnark backend";
-            commands = new String[]{RUN_PPZKSNARK, TRANSLATE, xjsnarkCircuit, xjsnarkInput,
+            missionName = "translate xjsnark input to libsnark backend";
+            commands = new String[]{RUN_PPZKSNARK, TRANSLATE_INPUT, xjsnarkCircuit, xjsnarkInput,
                     getPath(CIRCUIT_NAME), getPath(PRIMARY_IN), getPath(AUXILIARY_IN)};
             if (ce.execute(missionName, commands)) {
                 missionName = "generate proof";

--- a/src/main/java/com/abstrlabs/priceprover/TransactionSubmitter.java
+++ b/src/main/java/com/abstrlabs/priceprover/TransactionSubmitter.java
@@ -13,7 +13,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.Callable;
 
 @Log4j2
-@Command(name = "submit", description = "Call pagesigner-cli and notarize the stock price")
+@Command(name = "submit", description = "Sign an algorand transaction to submit the price and proof to chain")
 public class TransactionSubmitter implements Callable<Integer> {
 
     private static final String HEADERS = "headers";


### PR DESCRIPTION
```
priceprover (main) priceprover prove -xi out/aIBM-2022-05-05-20-43-38/input.in 
2022-05-07 15:19:11 INFO  CommandExecutor:49 - translate xjsnark input to libsnark backend start
2022-05-07 15:20:26 INFO  CommandExecutor:42 - translate xjsnark input to libsnark backend successfully
2022-05-07 15:20:26 INFO  CommandExecutor:49 - generate proof start
2022-05-07 15:21:08 INFO  CommandExecutor:42 - generate proof successfully
2022-05-07 15:21:08 INFO  CommandExecutor:49 - convert libsnark vk, primary input and proof to gnark format start
2022-05-07 15:21:10 INFO  CommandExecutor:42 - convert libsnark vk, primary input and proof to gnark format successfully
```

Using run_ppzksnark in https://github.com/AbstrLabs/libsnark/pull/2. Saved about 1 min in translate and 1 min in proof generation.